### PR TITLE
Clarify PR review and merge criteria

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 🚨 Before making any non-trivial change, please first open an issue describing the change to solicit feedback and guidance. This will increase the likelihood of the PR getting merged.
 
+In general, the smaller the diff the easier it will be for us to review quickly.
+
 Please note we have a [Code of Conduct](#code-of-conduct), please follow it in all your interactions with the project.
 
 # Pull Request Process
@@ -13,7 +15,7 @@ Please note we have a [Code of Conduct](#code-of-conduct), please follow it in a
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
 1. Update the README.md if your changes invalidate or extend its current content.
 1. Include tests for any new functionality.
-1. Reference relevant issues in your PR comment.
+1. Ensure each section of the [Pull Request Template](./PULL_REQUEST_TEMPLATE.md) is filled out.
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ Please note that we have a [Code of Conduct](#code-of-conduct), please follow it
 
 ## Steps for the PR author
 
+We recommend using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format on commit messages.
+
+Before opening a PR:
+
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
 1. Update the README.md if your changes invalidate or extend its current content.
 1. Include tests for any new functionality.
@@ -19,9 +23,10 @@ Please note that we have a [Code of Conduct](#code-of-conduct), please follow it
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
 
-We aim to provide a meaningful response to all PRs and issues from external contributors within 2 business days.
+**Bonus:** Add comments to the diff under the "Files Changed" tab on the PR page to clarify any sections where you think we might have questions about the approach taken.
 
-We recommend using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format on commit messages.
+### Response time:
+We aim to provide a meaningful response to all PRs and issues from external contributors within 2 business days.
 
 ## Steps for PR Reviewers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+🎈 Thanks for your help improving the project! We are so happy to have you!
+
 🚨 Before making any non-trivial change, please first open an issue describing the change to solicit feedback and guidance. This will increase the likelihood of the PR getting merged.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
@@ -9,39 +11,48 @@ Please note we have a code of conduct, please follow it in all your interactions
 ## Steps for the PR author
 
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
-2. Update the README.md if any changes invalidate or extend its current content.
-3. Include tests for any new functionality.
-4. Reference relevant issues in your PR comment.
+1. Update the README.md if your changes invalidate or extend its current content.
+1. Include tests for any new functionality.
+1. Reference relevant issues in your PR comment.
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
+
+We aim to provide a meaningful response to all PRs and issues from external contributors within 2 business days.
 
 ## Steps for PR Reviewers
 
 We distinguish between two classes of PR, those which modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
 
+In either case: once a code owner has reviewed and approved a PR, they should either merge it, or indicate what further review they deem necessary (and from whom). The intent here is to reduce the number of "approved" PRs which are not merged.
+
 ### 1. PRs which modify production code
 
-The reviewer's job is to check that the PR: 
+The reviewer's job is to check that the PR:
 
 1. Conforms to the specification (WIP, not yet public), or has an issue describing the additional functionality which a code owner has approved.
-2. Is appropriately tested.
-3. Does not introduce security issues.
+1. Is appropriately tested.
+1. Does not introduce security issues.
 
-After a code owner reviews and approves a PR, they should either merge it, or indicate what further review they deem necessary (and from whom). The intent here is to reduce the number of "approved" PRs which are not merged.
+#### Production Code Merge Criteria
 
-For production code PRs, the default assumption is that at least 2 code owners must approve.
-In the case of very simple changes, a single code owner may choose to merge at their discretion. 
+1. All CI checks MUST pass.
+1. At least 2 code owners must approve.
+1. In the case of very simple changes, a single code owner may choose to merge at their discretion.
 
 ### 2. Other PRs
 
-For PRs which do not modify production code (ie. test, dev tooling), 
+For PRs which do not modify production code (ie. test, dev tooling),
 
-The reviewer's job is to check that the PR: 
+The reviewer's job is to check that the PR:
 
 1. Is correct.
-2. Is desirable. 
+1. Is desirable.
 
-After a code owner reviews and approves a PR, they should either merge it, or indicate what further review they deem necessary (and from whom).
+#### Non-Production Code Merge Criteria
+
+1. All CI checks MUST pass
+1. A single
+1. In the case of very simple changes, a single code owner may choose to merge at their discretion.
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 In general, the smaller the diff the easier it will be for us to review quickly.
 
-Please note we have a [Code of Conduct](#code-of-conduct), please follow it in all your interactions with the project.
+Please note that we have a [Code of Conduct](#code-of-conduct), please follow it in all your interactions with the project.
 
 # Pull Request Process
 
@@ -21,23 +21,29 @@ Unless your PR is ready for immediate review and merging, please mark it as 'dra
 
 We aim to provide a meaningful response to all PRs and issues from external contributors within 2 business days.
 
+We recommend using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format on commit messages.
+
 ## Steps for PR Reviewers
 
-We distinguish between two classes of PR, those which modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
+### For all PRs
 
-In either case, once a code owner has reviewed and approved a PR, they should either:
-1. merge it, or
-1. indicate what further review they deem necessary (and from whom).
+Reviewers should submit their review with either `Approve` or `Request changes` options (not `Comment`).
 
-The intent here is to reduce the number of "approved" PRs which are not merged.
+If the reviewer selects `Request changes`, they should clearly indicate which changes they require in order to approve.
 
-### PRs which modify production code
+If the reviewer selects `Approves`, they should either:
+1. immediately merge it, or
+2. indicate what further review they deem necessary (and from whom).
+
+We further distinguish between two classes of PR those which modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
+
+### For PRs which modify production code
 
 The reviewer's job is to check that the PR:
 
-1. Conforms to the specification (WIP, not yet public), or has an issue describing the additional functionality which a code owner has approved.
-1. Is appropriately tested.
-1. Does not introduce security issues.
+1. Conforms to the specification (WIP, soon to be published here), or has an issue describing the additional functionality which a code owner has approved.
+2. Is appropriately tested.
+3. Does not introduce security issues.
 
 #### Merge Criteria
 
@@ -45,7 +51,7 @@ The reviewer's job is to check that the PR:
 1. At least 2 code owners must approve.
 1. In the case of very simple changes, a single code owner may choose to merge at their discretion.
 
-### PRs which modify non-production code
+### For PRs which modify non-production code
 
 For PRs which do not modify production code (ie. test, dev tooling),
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Unless your PR is ready for immediate review and merging, please mark it as 'dra
 
 ## Steps for PR Reviewers
 
-We distinguish between two classes of PR, those wich modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
+We distinguish between two classes of PR, those which modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
 
 ### 1. PRs which modify production code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note we have a [Code of Conduct](#code-of-conduct), please follow it in a
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
 1. Update the README.md if your changes invalidate or extend its current content.
 1. Include tests for any new functionality.
-1. Ensure each section of the [Pull Request Template](./PULL_REQUEST_TEMPLATE.md) is filled out.
+1. Ensure each section of the [Pull Request Template](./PULL_REQUEST_TEMPLATE.md) is filled out. Delete any sections that are not relevant.
 
 Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
 
@@ -56,9 +56,8 @@ The reviewer's job is to check that the PR:
 
 #### Merge Criteria
 
-1. All CI checks MUST pass
-1. A single
-1. In the case of very simple changes, a single code owner may choose to merge at their discretion.
+1. All CI checks MUST pass.
+1. At least one code owner must approve.
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 🚨 Before making any non-trivial change, please first open an issue describing the change to solicit feedback and guidance. This will increase the likelihood of the PR getting merged.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a [Code of Conduct](#code-of-conduct), please follow it in all your interactions with the project.
 
 # Pull Request Process
 
@@ -23,9 +23,13 @@ We aim to provide a meaningful response to all PRs and issues from external cont
 
 We distinguish between two classes of PR, those which modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
 
-In either case: once a code owner has reviewed and approved a PR, they should either merge it, or indicate what further review they deem necessary (and from whom). The intent here is to reduce the number of "approved" PRs which are not merged.
+In either case, once a code owner has reviewed and approved a PR, they should either:
+1. merge it, or
+1. indicate what further review they deem necessary (and from whom).
 
-### 1. PRs which modify production code
+The intent here is to reduce the number of "approved" PRs which are not merged.
+
+### PRs which modify production code
 
 The reviewer's job is to check that the PR:
 
@@ -33,13 +37,13 @@ The reviewer's job is to check that the PR:
 1. Is appropriately tested.
 1. Does not introduce security issues.
 
-#### Production Code Merge Criteria
+#### Merge Criteria
 
 1. All CI checks MUST pass.
 1. At least 2 code owners must approve.
 1. In the case of very simple changes, a single code owner may choose to merge at their discretion.
 
-### 2. Other PRs
+### PRs which modify non-production code
 
 For PRs which do not modify production code (ie. test, dev tooling),
 
@@ -48,7 +52,7 @@ The reviewer's job is to check that the PR:
 1. Is correct.
 1. Is desirable.
 
-#### Non-Production Code Merge Criteria
+#### Merge Criteria
 
 1. All CI checks MUST pass
 1. A single

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,44 @@
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
-## Pull Request Process
+# Pull Request Process
+
+## Steps for the PR author
 
 1. Ensure that tests pass and code is lint free. You can run `yarn test` and `yarn lint` locally to check.
-2. Update the README.md if any changes invalidate its current content.
+2. Update the README.md if any changes invalidate or extend its current content.
 3. Include tests for any new functionality.
 4. Reference relevant issues in your PR comment.
+
+Unless your PR is ready for immediate review and merging, please mark it as 'draft' (or simply do not open a PR yet).
+
+## Steps for PR Reviewers
+
+We distinguish between two classes of PR, those wich modify production code (ie. smart contracts, go-ethereum), and those which do not (ie. dev tooling, test scripts, comments).
+
+### 1. PRs which modify production code
+
+The reviewer's job is to check that the PR: 
+
+1. Conforms to the specification (WIP, not yet public), or has an issue describing the additional functionality which a code owner has approved.
+2. Is appropriately tested.
+3. Does not introduce security issues.
+
+After a code owner reviews and approves a PR, they should either merge it, or indicate what further review they deem necessary (and from whom). The intent here is to reduce the number of "approved" PRs which are not merged.
+
+For production code PRs, the default assumption is that at least 2 code owners must approve.
+In the case of very simple changes, a single code owner may choose to merge at their discretion. 
+
+### 2. Other PRs
+
+For PRs which do not modify production code (ie. test, dev tooling), 
+
+The reviewer's job is to check that the PR: 
+
+1. Is correct.
+2. Is desirable. 
+
+After a code owner reviews and approves a PR, they should either merge it, or indicate what further review they deem necessary (and from whom).
 
 ## Code of Conduct
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 <!--
+Please fill in each sections of this template, and delete any sections that are not relevant.
+
 Need help?
 Refer to our contributing guidelines for additional information about making a good pull request:
 https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
**Description**

My aim is to reduce the number of PRs which have one or more approvals, but are not merged. 

Based on my observations, I believe this is happening because: 
1. It's not clear how many people need to review a PR.
2. Even when a PR is read to be merged, we tend to leave it for the author to merge. 

The changes I'd add to our process are: 

1. PRs should be in draft unless the author is comfortable with it being merged immediately by a reviewer.
2. Code owners who review and approve a PR should either merge it immediately, or indicate what further review they deem necessary (and from whom).
3. **The author of the PR would no longer be the one to merge it.** AFAICT this point is a significant departure from our status quo flow.
